### PR TITLE
Updated readme and added maingroup var to prevent issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 user-func
 =========
 
-Role user-func aims to configure users in a functional way: the user configuration will be exactly the same, which is described in the config and guaranteed has no side-effects.
+Role user-func aims to configure users in a functional way: the user configuration will be exactly the same, which is described in the config and is guaranteed to have no side-effects.
 
 Description
 ------------
 
-The role is written on the assumption that the main entry point to the configuration is not the machine, but the user. That is, we do not want create a user on the machine, but we want to give user access to certain machines instead.
+The role is written on the assumption that the main entry point to the configuration is not the machine, but the user. That is, we do not want to create a user on the machine, but we want to give the user access to certain machines instead.
 
 You can:
 - manage your user public keys database
-- can set multiple keys for one user
-- can delete users (home directories ain't removed)
-- can lock/unlock password auth
+- set multiple keys for one user
+- delete users (home directories aren't removed)
+- lock/unlock password auth
 - set local configuration per host or ansible group of hosts
 
 Role Variables
@@ -20,17 +20,19 @@ Role Variables
 
 Parameters are divided into global and local. If the parameter is described locally to the host (in the hosts dictionary), then the global parameter is taken. If the global parameter is not described, the default value is taken.
 
-username: Required, specifies the user name on the machine
+username: mandatory, specifies the user name on the machine
+
+maingroup: mandatory, to add a default group to prevent missing user group assignment when the user already exist on the host. 
 
 hosts: mandatory parameter, defines the list of hosts to which the user will have access and their local configuration
 
-give_sudo: the sudo/wheel group is taken to a separate parameter in view of of exceptional importance. This parameter determines whether to give the user has the right to start sudo or not to give. Can be used in the local host configuration. Default no.
+give_sudo: the sudo/wheel group is taken to a separate parameter in view of exceptional importance. This parameter determines whether to give the user rights to start sudo or not to give. Can be used in the local host configuration. Default no.
 
 password: sets the password for the user. Can be used in local configuration.
 
-lock_password: sets the password lock. If set to yes, then for the user is not allowed to enter the password (in shadow is set '*'). May be used locally. Default no.
+lock_password: sets the password lock. If set to yes, then the user is not allowed to enter the password (in shadow is set '*'). May be used locally. Default no.
 
-disable_user: blocking the login for the user. If set to yes, then the input under the given user is impossible including on ssh (the default shell is installed in nologin). Can be used locally. Default no.
+disable_user: block the login for the user. If set to yes, then the input under the given user is impossible including on ssh (the default shell is installed in nologin). Can be used locally. Default no.
 
 delete_user: deletes the user (but not his home directory). Can be used locally. Default no. Use with caution, and it is better not to use at all - disable_user more the preferred option.
 
@@ -58,26 +60,29 @@ Example 1 (short)
       vars:
         common_groups: [ users ]
       roles:
-    
+
         - tags: [ admins, freehck ]
           role: user-func
+          maingroup: freehck
           username: freehck
           give_sudo: yes
           authorized_keys: [ freehck ]
           hosts:
             - host: all
-    
+
         - tags: [ special, jenkins ]
           role: user-func
+          maingroup: jenkins
           username: jenkins
           authorized_keys: [ jenkins, jenkins-slave01, jenkins-slave02 ]
           hosts:
             - host: all
             - host: jenkins-slave01
               groups: [ docker ]
-    
+
         - tags: [ testers, tester ]
           role: user-func
+          maingroup: tester
           username: tester
           authorized_keys: [ tester ]
           hosts:
@@ -91,13 +96,13 @@ Example 1 (short)
       - name: freehck
         fullname: Dmitrii Kashin
         key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPSD4/7GDGnHuFr/p/ZmDoW0RZ/3bHvoI/s5WwOpARJuqgnzj2CyfiPxkKzvCuncUq8O8FfjnAyyj7pEIV2MSEQnxzoFDfcJHRH4sw68TLlGENUvQjtTqrZQ2fyZ6Nu7dktq4A3aOxV0rVZa2oJMA1V1LFj5y9u9B4Sj1pSuY0HkAF1XHJDyBQUs8ncrBkwakqCw0wKI7aLC6tph4whFzJqs8LSnwrR6kMMyVC2xjaw8vczM1wcYVfc6lPN7tWJTH3GrjQRdEYEJo3VqInoiQ9OKb171fMrp9N1u6a88ffTDdX3Jlgm8MRSItuGkdJ9tNXke/hq7GuKmavx7sMf34d freehck
-    
+
       - name: jenkins
         key: ...
-    
+
       - name: jenkins-slave01
         key: ...
-    
+
       - name: jenkins-slave02
         key: ...
 
@@ -106,6 +111,7 @@ Example 2 (with all possible options)
 
     - role: user-func
       username: freehck # required
+      maingroup: freehck # required
       give_sudo: no
       password: "mysecret"
       lock_password: no

--- a/tasks/create-user.yml
+++ b/tasks/create-user.yml
@@ -8,7 +8,7 @@
   set_fact:
     new_shell: "{{nologin_shell}}"
   when: host.disable_user | default(disable_user)
-  
+
 - name: check user password [{{username}}]
   set_fact:
     new_password: "{{ host.password | default(password) | password_hash('sha512') }}"
@@ -60,7 +60,7 @@
     - ssh_public_keys is defined
     - ssh_public_keys | selectattr('name', 'equalto', item) | list | length == 0
   with_items: "{{ (host.authorized_keys | default(authorized_keys)) }}"
-  
+
 - name: set authorized ssh keys [{{username}}]
   template:
     src: authorized_keys.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
     msg: 'no username provided'
   when: username is undefined
 
+- name: check maingroup
+  fail:
+    msg: 'no maingroup provided'
+  when: maingroup is undefined
+
 - name: set facts
   set_fact:
     apply_to_this_host: no
@@ -19,7 +24,7 @@
       {%- elif (ansible_os_family in [ 'RedHat' ]) -%} wheel
       {%- else -%} sudo
       {%- endif -%}
-  
+
 - name: lookup user definition for this host
   set_fact: user_host_list={{ user_host_list|default([]) + hosts | selectattr('host', 'equalto', item) | list }}
   with_items:
@@ -27,14 +32,6 @@
     - "{{ansible_nodename}}"
     - "{{group_names}}"
     - all
-
-#- name: check duplicate entries for user '{{username}}'
-#  fail:
-#    msg: "Found duplicates. Omit host."
-#  when: user_host_list | dedup | length > 1
-
-# потому что jenkins должен быть на всех машинах (all), но только на
-# тех нодах, где есть docker, должен быть в его группе (prod07)
 
 - name: check if we shall apply user settings to this host
   set_fact:


### PR DESCRIPTION
Updated readme and added maingroup var to prevent issues

maingroup var is useful when user already exist on the host and it has assigned a managed group by a 3rd party tool or user management like FreeIPA or other. 

